### PR TITLE
update Fletch hash and switch PROJ4 to PROJ

### DIFF
--- a/CMake/telesculptor-external-fletch.cmake
+++ b/CMake/telesculptor-external-fletch.cmake
@@ -14,7 +14,7 @@ endif()
 ExternalProject_Add(fletch
   PREFIX ${TELESCULPTOR_BINARY_DIR}
   GIT_REPOSITORY "git://github.com/Kitware/fletch.git"
-  GIT_TAG 3b86acd1ed15e566550e43a35634c35b594e0329
+  GIT_TAG cf4538470395204a2233930d66f6bf2d75550319
   #GIT_SHALLOW 1
   SOURCE_DIR ${TELESCULPTOR_EXTERNAL_DIR}/fletch
   BINARY_DIR ${TELESCULPTOR_EXTERNAL_DIR}/fletch-build
@@ -52,7 +52,7 @@ ExternalProject_Add(fletch
     -Dfletch_ENABLE_OpenCV_highgui:BOOL=ON
     -Dfletch_ENABLE_PDAL:BOOL=ON
     -Dfletch_ENABLE_PNG:BOOL=ON
-    -Dfletch_ENABLE_PROJ4:BOOL=ON
+    -Dfletch_ENABLE_PROJ:BOOL=ON
     -Dfletch_ENABLE_PostGIS:BOOL=OFF
     -Dfletch_ENABLE_PostgresSQL:BOOL=OFF
     -Dfletch_ENABLE_Protobuf:BOOL=OFF

--- a/CMake/telesculptor-external-kwiver.cmake
+++ b/CMake/telesculptor-external-kwiver.cmake
@@ -18,7 +18,7 @@ ExternalProject_Add(kwiver
   BINARY_DIR ${TELESCULPTOR_EXTERNAL_DIR}/kwiver-build
   STAMP_DIR ${TELESCULPTOR_STAMP_DIR}
   GIT_REPOSITORY "https://github.com/Kitware/kwiver.git"
-  GIT_TAG ff8da686e8c501bcad11da6997cbb7753fc41abc
+  GIT_TAG 053f5aaa9962caf3e536fba34fcc4e5dd44b709e
   #GIT_SHALLOW 1
   CMAKE_CACHE_ARGS
     -DBUILD_SHARED_LIBS:BOOL=ON


### PR DESCRIPTION
I am testing a build with these changes now (will take a while) but I think we have the issue of the new KWIVER hash also having PROJ upgrades but the Fletch hash did not have the updated PROJ.